### PR TITLE
refactor: removed unused includes & minor corrections in logic

### DIFF
--- a/clueapi/impl/clueapi.cxx
+++ b/clueapi/impl/clueapi.cxx
@@ -57,7 +57,7 @@ namespace clueapi {
                     port
                 );
 
-                if (ec != std::errc{} || port <= 0) {
+                if (ec != std::errc{} || port == 0) {
                     CLUEAPI_LOG_WARNING("Port number '{}' is not supported, using '8080' instead", m_cfg.m_port);
 
                     port = 8080;
@@ -129,8 +129,8 @@ namespace clueapi {
                 if (!m_running.load(std::memory_order_acquire))
                     return;
 
-                m_running.store(false, std::memory_order_seq_cst);
-                
+                m_running.store(false, std::memory_order_release);
+
                 { std::lock_guard lock(m_wait_mutex); }
 
                 if (m_signals.has_value()) {

--- a/clueapi/server/impl/server.cxx
+++ b/clueapi/server/impl/server.cxx
@@ -156,7 +156,7 @@ namespace clueapi::server {
 
             const auto workers = workers_count > 0 ? workers_count : std::thread::hardware_concurrency();
 
-            if (workers_count <= 0) {
+            if (workers_count == 0) {
                 CLUEAPI_LOG_DEBUG(
                     "Overriding workers count to {} based on hardware concurrency",
 

--- a/clueapi/shared/pch/pch.hxx
+++ b/clueapi/shared/pch/pch.hxx
@@ -10,8 +10,6 @@
 #include <memory>
 #include <mutex>
 #include <optional>
-#include <queue>
-#include <regex>
 #include <shared_mutex>
 #include <string>
 #include <string_view>
@@ -32,7 +30,6 @@
 #include <boost/asio.hpp>
 #include <boost/asio/stream_file.hpp>
 #include <boost/asio/this_coro.hpp>
-#include <boost/url.hpp>
 
 #include <boost/beast.hpp>
 #include <boost/beast/websocket.hpp>
@@ -43,14 +40,6 @@
 #include <boost/algorithm/string/predicate.hpp>
 
 #include <boost/filesystem.hpp>
-
-#include <boost/uuid/uuid.hpp>
-#include <boost/uuid/uuid_generators.hpp>
-#include <boost/uuid/uuid_io.hpp>
-
-#include <boost/iostreams/device/mapped_file.hpp>
-
-#include <boost/date_time/posix_time/posix_time.hpp>
 
 #include <boost/lexical_cast.hpp>
 


### PR DESCRIPTION
removed: unused libraries from precompiled headers

fixed: the correct memory order for m_running is set when the application is stopped.

fixed: excessive port invalidity check (comparison of unsigned value with <= 0).
fixed: excessive workers count check (comparison of unsigned value with <= 0).